### PR TITLE
hide hullmod Finisher Beam Protocol if the mod Advanced Gunnery Control is enabled

### DIFF
--- a/launcher/src/com/genir/aitweaks/launcher/AITweaksBaseModPlugin.kt
+++ b/launcher/src/com/genir/aitweaks/launcher/AITweaksBaseModPlugin.kt
@@ -1,6 +1,7 @@
 package com.genir.aitweaks.launcher
 
 import com.fs.starfarer.api.BaseModPlugin
+import com.fs.starfarer.api.Global
 import com.fs.starfarer.api.PluginPick
 import com.fs.starfarer.api.combat.AutofireAIPlugin
 import com.fs.starfarer.api.combat.ShipAIPlugin
@@ -11,6 +12,8 @@ import com.genir.aitweaks.launcher.loading.CoreLoaderManager.coreLoader
 import com.genir.aitweaks.launcher.loading.CoreLoaderManager.instantiate
 
 class AITweaksBaseModPlugin : BaseModPlugin() {
+    companion object { var advancedGunneryControlNotFound = true }
+
     override fun pickWeaponAutofireAI(weapon: WeaponAPI): PluginPick<AutofireAIPlugin>? {
         val picker: AutofireAIPicker = coreLoader.loadClass("com.genir.aitweaks.core.shipai.autofire.AutofireAIPicker").instantiate()
         return picker.pickWeaponAutofireAI(weapon)
@@ -27,6 +30,10 @@ class AITweaksBaseModPlugin : BaseModPlugin() {
 
     override fun afterGameSave() {
         MakeAITweaksRemovable.afterGameSave()
+    }
+
+    override fun onApplicationLoad() {
+        advancedGunneryControlNotFound = !Global.getSettings().modManager.isModEnabled("advanced_gunnery_control_dbeaa06e")
     }
 
     override fun onGameLoad(newGame: Boolean) {

--- a/launcher/src/com/genir/aitweaks/launcher/hullmods/FinisherBeamProtocol.kt
+++ b/launcher/src/com/genir/aitweaks/launcher/hullmods/FinisherBeamProtocol.kt
@@ -2,10 +2,11 @@ package com.genir.aitweaks.launcher.hullmods
 
 import com.fs.starfarer.api.combat.BaseHullMod
 import com.fs.starfarer.api.combat.ShipAPI
+import com.genir.aitweaks.launcher.AITweaksBaseModPlugin
 
 class FinisherBeamProtocol : BaseHullMod() {
     override fun showInRefitScreenModPickerFor(ship: ShipAPI): Boolean {
-        return enableHullmods()
+        return AITweaksBaseModPlugin.advancedGunneryControlNotFound && enableHullmods()
     }
 
     override fun getDescriptionParam(index: Int, hullSize: ShipAPI.HullSize?): String? = when (index) {


### PR DESCRIPTION
Original feature request: https://fractalsoftworks.com/forum/index.php?topic=28428.msg496564#msg496564

~~Sorry for not testing it: I could not get the .jars to generate. Selected 'include in build' as one does, but the build always "succeeds" without any .jar files appearing.~~

~~What I did test is that `ModManagerAPI#isModEnabled` returns the correct value in `onApplicationLoad` when I add it to my own starsector-vanilla-tweaks mod.~~

Tested now. I had to restart IntelliJ IDEA before it would generate the .jars. Works as expected.